### PR TITLE
🐛 FIX: update config phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
     - src/DataFixtures
     - src/Command
     #- src/Services/Dashboard/DashboardService.php
-  checkMissingIterableValueType: true
+  # checkMissingIterableValueType: true
   reportUnmatchedIgnoredErrors: false
   editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
   editorUrlTitle: '%%relFile%%:%%line%%'


### PR DESCRIPTION
# CI/CD ECHEC

### Phpstan
La CI échoue à cause d'un paramètre invalide dans la configuration: paramètre masqué.