### PR TITLE
Revert RabbitMQ → Doctrine Transport (fix prod)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php-flasher/flasher-symfony": "^2.1",
         "phpdocumentor/reflection-docblock": "^5.6",
         "phpstan/phpdoc-parser": "^2.1",
-        "symfony/amqp-messenger": "7.3.*",
         "symfony/asset": "7.3.*",
         "symfony/asset-mapper": "7.3.*",
         "symfony/console": "7.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c10f7bad6ff495b4de2441018d21e94",
+    "content-hash": "426115b0bd2cdde9f390d9418dfc8390",
     "packages": [
         {
             "name": "composer/semver",
@@ -2683,79 +2683,6 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
             },
             "time": "2025-07-11T13:20:48+00:00"
-        },
-        {
-            "name": "symfony/amqp-messenger",
-            "version": "v7.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/amqp-messenger.git",
-                "reference": "0ed5f72c1d9bbfcfc751b3832939a00a3246fe98"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/amqp-messenger/zipball/0ed5f72c1d9bbfcfc751b3832939a00a3246fe98",
-                "reference": "0ed5f72c1d9bbfcfc751b3832939a00a3246fe98",
-                "shasum": ""
-            },
-            "require": {
-                "ext-amqp": "*",
-                "php": ">=8.2",
-                "symfony/messenger": "^7.3"
-            },
-            "require-dev": {
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/process": "^6.4|^7.0",
-                "symfony/property-access": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0"
-            },
-            "type": "symfony-messenger-bridge",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Messenger\\Bridge\\Amqp\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony AMQP extension Messenger Bridge",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/amqp-messenger/tree/v7.3.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-15T11:36:08+00:00"
         },
         {
             "name": "symfony/asset",

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -7,8 +7,8 @@ framework:
             async:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 options:
-                    # use_notify: true
-                    # check_delayed_interval: 60000
+                    use_notify: true
+                    check_delayed_interval: 60000
                 retry_strategy:
                     max_retries: 3
                     multiplier: 2

--- a/src/Command/Scheduler/SendMailCommand.php
+++ b/src/Command/Scheduler/SendMailCommand.php
@@ -6,9 +6,10 @@ use App\Message\SendReminderEmails;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Scheduler\Attribute\AsCronTask;
+use App\Message\MessageHandler\SendReminderEmailsHandler;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[AsCommand(
     name: 'app:send-mail',
@@ -24,7 +25,9 @@ use Symfony\Component\Scheduler\Attribute\AsCronTask;
 class SendMailCommand extends Command
 {
     public function __construct(
-        private readonly MessageBusInterface $bus
+        // private readonly MessageBusInterface $bus // RabbitMQ
+        private readonly SendReminderEmailsHandler $handler,
+        private readonly ParameterBagInterface $parameterBag
     ) {
         parent::__construct();
     }
@@ -34,11 +37,103 @@ class SendMailCommand extends Command
         $this->setHelp(help: 'Cette commande envoie des emails de rappel aux tuteurs qui ont des modules en attente de validation.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    // Rabbit MQ quand il sera opérationnel !!
+    /* protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->bus->dispatch(new SendReminderEmails(triggeredAt: new \DateTimeImmutable()));
         $output->writeln('📨 Message "SendReminderEmails" dispatché vers RabbitMQ');
 
         return Command::SUCCESS;
+    } */
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $executionStart = new \DateTimeImmutable();
+        $output->writeln('🚀 Début du traitement des emails de rappel...');
+
+        try {
+            $message = new SendReminderEmails(triggeredAt: $executionStart);
+            $result = $this->handler->__invoke($message);
+
+            $this->createSuccessLog($result, $executionStart);
+
+            $output->writeln(sprintf(
+                '✅ Emails de rappel envoyés avec succès - %d emails envoyés pour %d modules en attente',
+                $result['emails_sent'],
+                $result['total_pending_modules']
+            ));
+
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            $this->createErrorLog($e, $executionStart);
+
+            $output->writeln('❌ Erreur durant le traitement des emails de rappel');
+            $output->writeln('Détails: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function createSuccessLog(array $result, \DateTimeImmutable $executionStart): void
+    {
+        $executionEnd = new \DateTimeImmutable();
+        $logDir = $this->getLogDirectory();
+        $logFile = $logDir . '/' . $executionStart->format('Y-m-d_H-i-s') . '-mail-success.log';
+
+        $logData = [
+            'execution_date' => $executionStart->format('c'),
+            'execution_duration' => $executionEnd->getTimestamp() - $executionStart->getTimestamp(),
+            'status' => 'SUCCESS',
+            'summary' => [
+                'emails_sent' => $result['emails_sent'],
+                'total_pending_modules' => $result['total_pending_modules'],
+                'mentors_contacted' => count($result['sent_emails'])
+            ],
+            'emails_details' => $result['sent_emails']
+        ];
+
+        $this->writeLog($logFile, $logData);
+    }
+
+    private function createErrorLog(\Exception $exception, \DateTimeImmutable $executionStart): void
+    {
+        $executionEnd = new \DateTimeImmutable();
+        $logDir = $this->getLogDirectory();
+        $logFile = $logDir . '/' . $executionStart->format('Y-m-d_H-i-s') . '-mail-error.log';
+
+        $logData = [
+            'execution_date' => $executionStart->format('c'),
+            'execution_duration' => $executionEnd->getTimestamp() - $executionStart->getTimestamp(),
+            'status' => 'ERROR',
+            'error' => [
+                'message' => $exception->getMessage(),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+                'trace' => $exception->getTraceAsString()
+            ]
+        ];
+
+        $this->writeLog($logFile, $logData);
+    }
+
+    private function getLogDirectory(): string
+    {
+        $projectDir = $this->parameterBag->get('kernel.project_dir');
+        if (!is_string($projectDir)) {
+            throw new \InvalidArgumentException('kernel.project_dir must be a string');
+        }
+
+        $logDir = $projectDir . '/var/log/emails';
+        if (!is_dir($logDir)) {
+            mkdir($logDir, 0755, true);
+        }
+
+        return $logDir;
+    }
+
+    private function writeLog(string $logFile, array $logData): void
+    {
+        $jsonLog = json_encode($logData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        file_put_contents($logFile, $jsonLog);
     }
 }

--- a/src/Message/MessageHandler/SendReminderEmailsHandler.php
+++ b/src/Message/MessageHandler/SendReminderEmailsHandler.php
@@ -29,7 +29,11 @@ final class SendReminderEmailsHandler
     ) {
     }
 
-    public function __invoke(SendReminderEmails $message): void
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(SendReminderEmails $message): array
     {
         $logbooks = $this->logbookRepository->findAllWithOwnerAndMentor();
         $mentorsWithPending = $this->logbookProgressService->getMentorsWithPendingValidations($logbooks);
@@ -40,8 +44,16 @@ final class SendReminderEmailsHandler
         }
         $logoPath = $projectDir . '/public/images/logos/edf.png';
 
+        $sentEmails = [];
+        $totalPendingModules = 0;
+
         foreach ($mentorsWithPending['mentors_with_pending_modules'] as $mentorData) {
+            // Extraire les informations détaillées du mentor et des modules
             $reminderData = $this->reminderService->prepareReminderData($mentorData);
+
+            // Compter les modules en attente pour ce mentor
+            $pendingModulesCount = $reminderData['pending_modules_count'];
+            $totalPendingModules += $pendingModulesCount;
 
             $contentId = 'logo@gna-edf.fr';
             $reminderData['logo_cid'] = $contentId;
@@ -63,7 +75,35 @@ final class SendReminderEmailsHandler
                 $email->html($htmlContent);
             }
 
-            $this->mailer->send($email);
+            try {
+                $this->mailer->send($email);
+
+                // Enregistrer les détails de l'email envoyé
+                $sentEmails[] = [
+                    'tuteur_email' => $mentorData['mentor_email'],
+                    'tuteur_nom' => $mentorData['mentor_firstname'],
+                    'tuteur_nni' => $mentorData['mentor_nni'] ?? 'N/A',
+                    'modules_en_attente' => $pendingModulesCount,
+                    'apprenant' => $mentorData['owner_fullname'],
+                ];
+            } catch (\Exception $e) {
+                // En cas d'erreur d'envoi, on relance l'exception pour qu'elle soit gérée par la commande
+                throw new \RuntimeException(
+                    sprintf('Erreur lors de l\'envoi de l\'email à %s: %s', $mentorData['mentor_email'], $e->getMessage()),
+                    0,
+                    $e
+                );
+            }
         }
+
+        return [
+            'emails_sent' => count($sentEmails),
+            'total_pending_modules' => $totalPendingModules,
+            'sent_emails' => $sentEmails,
+            'execution_summary' => [
+                'total_mentors_processed' => count($mentorsWithPending['mentors_with_pending_modules']),
+                'total_logbooks_analyzed' => count($logbooks)
+            ]
+        ];
     }
 }


### PR DESCRIPTION
# ♻️ Revert RabbitMQ → Doctrine Transport (fix prod)

## Objectif

Cette Pull Request corrige un problème rencontré en production avec RabbitMQ.  
RabbitMQ n’étant pas fonctionnel dans l’environnement actuel, le transport a été **rebasculé vers Doctrine** afin de garantir la continuité du service d’envoi d’emails automatisés.

---

## ✅ Changements apportés

- Mise à jour des dépendances :  
  `composer.json` / `composer.lock`
- Reconfiguration du transport Messenger vers Doctrine :  
  `config/packages/messenger.yaml`
- Adaptation des commandes et handlers impactés :  
  - `src/Command/Scheduler/SendMailCommand.php`  
  - `src/Message/MessageHandler/SendReminderEmailsHandler.php`

---

## 🔍 Commit concerné

- `b532f24` fix: REVERT rabbitmq vers doctrine (non fonctionnel en prod)

---

## 📝 Remarques

Ce revert est temporaire, le but étant de stabiliser le système en production.  
Une nouvelle tentative de mise en place de RabbitMQ pourra être réalisée ultérieurement après diagnostic et validation des prérequis en environnement prod.
